### PR TITLE
Add a custom session scoped `event_loop` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ routes = [
 app = Starlette(routes=routes)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 async def server():
     config = Config(app=app, lifespan="off")
     server = Server(config=config)
@@ -76,3 +76,10 @@ async def server():
         yield server
     finally:
         task.cancel()
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.get_event_loop()
+    yield loop
+    loop.close()


### PR DESCRIPTION
While trying to run the tests on my MacBook running Mojave and Python 3.7 I found that the tests hang after the first or second test that makes a request to the `server` fixture. By "hang" I mean the test run stops indefinitely and I'm forced to `kill -9` the process.

Using a session scoped `event_loop` fixture seems to work around it, I am not sure why or if this is an acceptable fix, but I thought I'd share it.