### PR TITLE
Populate `Response._next` when `allow_redirects=False`

### DIFF
--- a/requests_async/sessions.py
+++ b/requests_async/sessions.py
@@ -165,13 +165,14 @@ class Session(requests.Session):
             r.history = history
 
         # If redirects aren't being followed, store the response on the Request for Response.next().
-        # if not allow_redirects:
-        #     try:
-        #         r._next = next(
-        #             self.resolve_redirects(r, request, yield_requests=True, **kwargs)
-        #         )
-        #     except StopIteration:
-        #         pass
+        if not allow_redirects:
+            try:
+                redirect_gen = self.resolve_redirects(
+                    r, request, yield_requests=True, **kwargs
+                )
+                r._next = await redirect_gen.__anext__()
+            except StopAsyncIteration:
+                pass
 
         if not stream:
             r.content

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -19,3 +19,5 @@ async def test_redirects_disallowed(server):
     assert response.status_code == 302
     assert response.url == "http://127.0.0.1:8000/redirect1"
     assert len(response.history) == 0
+    assert isinstance(response.next, requests_async.models.PreparedRequest)
+    assert response.next.url == "http://127.0.0.1:8000/redirect2"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -35,3 +35,16 @@ async def test_session(server):
         response = await session.head(url)
         assert response.status_code == 200
         assert response.text == ""
+
+
+@pytest.mark.asyncio
+async def test_session_redirection_disallowed(server):
+    url = "http://127.0.0.1:8000/redirect1"
+    with requests_async.Session() as session:
+        response = await session.get(url, allow_redirects=False)
+        assert response.status_code == 302
+        response = await session.send(response.next, allow_redirects=False)
+        assert response.status_code == 302
+        response = await session.send(response.next, allow_redirects=False)
+        assert response.status_code == 200
+        assert response.url == "http://127.0.0.1:8000/redirect3"


### PR DESCRIPTION
Fixes #9 

Requests populates the `next` property with a `PreparedRequest` to the redirected URL, this MR introduces the same behaviour.