### PR TITLE
Encode the request body of the PreparedRequest defaulting to latin-1

### DIFF
--- a/requests_async/adapters.py
+++ b/requests_async/adapters.py
@@ -1,4 +1,5 @@
 import asyncio
+from http.client import _encode
 import io
 import ssl
 import typing
@@ -56,7 +57,10 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
         writer.write(data)
 
         if request.body:
-            message = h11.Data(data=request.body.encode("utf-8"))
+            body = (
+                _encode(request.body) if isinstance(request.body, str) else request.body
+            )
+            message = h11.Data(data=body)
             data = conn.send(message)
             writer.write(data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,13 @@ async def echo_form_data(request):
     )
 
 
+async def echo_json(request):
+    json = await request.json()
+    return JSONResponse(
+        {"method": request.method, "url": str(request.url), "json": json}
+    )
+
+
 async def echo_headers(request):
     return JSONResponse(
         {"headers": {key: value for key, value in request.headers.items()}}
@@ -56,6 +63,7 @@ routes = [
         "/", echo_request, methods=["GET", "DELETE", "OPTIONS", "POST", "PUT", "PATCH"]
     ),
     Route("/echo_form_data", echo_form_data, methods=["POST", "PUT", "PATCH"]),
+    Route("/echo_json", echo_json, methods=["POST", "PUT", "PATCH"]),
     Route("/echo_headers", echo_headers),
     Route("/redirect1", redirect1, name="redirect1"),
     Route("/redirect2", redirect2, name="redirect2"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,5 +114,3 @@ async def test_raw_strings_not_latin1_raise_error(server):
     url = "http://127.0.0.1:8000/"
     with pytest.raises(UnicodeEncodeError):
         await requests_async.post(url, data="Łukasz")
-
-    # TODO: The event loop does not exit cleanly

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,24 @@ async def test_post_with_data(server):
     assert response.json() == {"method": "POST", "url": url, "form": {"a": "b"}}
 
 
+@pytest.mark.parametrize("data", ["raw string", b"raw bytes"])
+@pytest.mark.asyncio
+async def test_post_with_data_raw_data(server, data):
+    url = "http://127.0.0.1:8000/"
+    response = await requests_async.post(url, data="raw string")
+    expected = data if isinstance(data, str) else data.decode("latin-1")
+    assert response.status_code == 200
+    assert response.json() == {"method": "POST", "url": url, "body": "raw string"}
+
+
+@pytest.mark.asyncio
+async def test_post_with_json(server):
+    url = "http://127.0.0.1:8000/echo_json"
+    response = await requests_async.post(url, json={"a": "b"})
+    assert response.status_code == 200
+    assert response.json() == {"method": "POST", "url": url, "json": {"a": "b"}}
+
+
 @pytest.mark.asyncio
 async def test_put_with_data(server):
     url = "http://127.0.0.1:8000/echo_form_data"
@@ -68,8 +86,33 @@ async def test_put_with_data(server):
 
 
 @pytest.mark.asyncio
+async def test_put_with_json(server):
+    url = "http://127.0.0.1:8000/echo_json"
+    response = await requests_async.put(url, json={"a": "b"})
+    assert response.status_code == 200
+    assert response.json() == {"method": "PUT", "url": url, "json": {"a": "b"}}
+
+
+@pytest.mark.asyncio
 async def test_patch_with_data(server):
     url = "http://127.0.0.1:8000/echo_form_data"
     response = await requests_async.patch(url, data={"a": "b"})
     assert response.status_code == 200
     assert response.json() == {"method": "PATCH", "url": url, "form": {"a": "b"}}
+
+
+@pytest.mark.asyncio
+async def test_patch_with_json(server):
+    url = "http://127.0.0.1:8000/echo_json"
+    response = await requests_async.patch(url, json={"a": "b"})
+    assert response.status_code == 200
+    assert response.json() == {"method": "PATCH", "url": url, "json": {"a": "b"}}
+
+
+@pytest.mark.asyncio
+async def test_raw_strings_not_latin1_raise_error(server):
+    url = "http://127.0.0.1:8000/"
+    with pytest.raises(UnicodeEncodeError):
+        await requests_async.post(url, data="Łukasz")
+
+    # TODO: The event loop does not exit cleanly


### PR DESCRIPTION
Fixes #12.

PreparedRequests encode JSON payloads as UTF-8, form data is URL encoded as a string and eventually passed on to the standard library's `http.client._encode` function which default to `latin-1`.

I've set this PR to WIP because the new `test_raw_strings_not_latin1_raise_error` is not playing well with the server fixture. It seems the server is catching a `GeneratorExit` exception and attempting to send a 500 response, but the event loop is closed and which produces a `Task was destroyed but it was pending` error. Here's the output:

```
=== 1 passed, 14 deselected in 0.14 seconds ===
Task was destroyed but it is pending!
task: <Task pending coro=<RequestResponseCycle.run_asgi() running at /Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py:372> wait_for=<Future cancelled> cb=[set.disc
ard()]>
Exception in ASGI application
Traceback (most recent call last):
  File "/Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 372, in run_asgi
    result = await asgi(self.receive, self.send)
GeneratorExit
Fatal write error on socket transport
protocol: <uvicorn.protocols.http.httptools_impl.HttpToolsProtocol object at 0x1024ebf60>
transport: <_SelectorSocketTransport fd=8>
Traceback (most recent call last):
  File "/Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 372, in run_asgi
    result = await asgi(self.receive, self.send)
GeneratorExit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/selector_events.py", line 752, in write
    n = self._sock.send(data)
OSError: [Errno 9] Bad file descriptor
Exception ignored in: <coroutine object RequestResponseCycle.run_asgi at 0x10243d4c0>
Traceback (most recent call last):
  File "/Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 377, in run_asgi
    await self.send_500_response()
  File "/Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 403, in send_500_response
    (b"connection", b"close"),
  File "/Users/yeray/.pyenv/versions/3.6.8/envs/requests-async/lib/python3.6/site-packages/uvicorn/protocols/http/httptools_impl.py", line 468, in send
    self.transport.write(b"".join(content))
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/selector_events.py", line 756, in write
    self._fatal_error(exc, 'Fatal write error on socket transport')
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/selector_events.py", line 634, in _fatal_error
    self._force_close(exc)
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/selector_events.py", line 646, in _force_close
    self._loop.call_soon(self._call_connection_lost, exc)
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/base_events.py", line 591, in call_soon
    self._check_closed()
  File "/Users/yeray/.pyenv/versions/3.6.8/lib/python3.6/asyncio/base_events.py", line 377, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

I'm not sure why that `GeneratorExit` is happening since the request is never actually sent in the test. I can only imagine there's a conflict with our test setup. Any ideas?