### PR TITLE
Don't subclass HTTPAdapter

### DIFF
--- a/requests_async/adapters.py
+++ b/requests_async/adapters.py
@@ -47,7 +47,7 @@ def get_ssl(urlparts, verify, cert):
     return verify_context(cert)
 
 
-class HTTPAdapter(requests.adapters.HTTPAdapter):
+class HTTPAdapter:
     async def send(
         self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
     ) -> requests.Response:
@@ -141,3 +141,39 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
 
     async def close(self):
         pass
+
+    def build_response(self, req, resp):
+        """Builds a :class:`Response <requests.Response>` object from a urllib3
+        response. This should not be called from user code, and is only exposed
+        for use when subclassing the
+        :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`
+        :param req: The :class:`PreparedRequest <PreparedRequest>` used to generate the response.
+        :param resp: The urllib3 response object.
+        :rtype: requests.Response
+        """
+        response = requests.models.Response()
+
+        # Fallback to None if there's no status_code, for whatever reason.
+        response.status_code = getattr(resp, 'status', None)
+
+        # Make headers case-insensitive.
+        response.headers = requests.structures.CaseInsensitiveDict(getattr(resp, 'headers', {}))
+
+        # Set encoding.
+        response.encoding = requests.utils.get_encoding_from_headers(response.headers)
+        response.raw = resp
+        response.reason = response.raw.reason
+
+        if isinstance(req.url, bytes):
+            response.url = req.url.decode('utf-8')
+        else:
+            response.url = req.url
+
+        # Add new cookies from the server.
+        requests.cookies.extract_cookies_to_jar(response.cookies, req, resp)
+
+        # Give the Response some context.
+        response.request = req
+        response.connection = self
+
+        return response


### PR DESCRIPTION
Don't subclass the existing HTTPAdapter implementation.

Having less indirection is a win here, and will make any further refactoring easier.