### PR TITLE
fix missing module `socket`

### DIFF
--- a/requests_async/adapters.py
+++ b/requests_async/adapters.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import os
+import socket
 import ssl
 import typing
 from http.client import _encode


### PR DESCRIPTION
`socket` module is not imported in adapter.py, it will cause `NameError: name 'socket' is not defined`.