### PR TITLE
Freeze version of httpcore to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpcore==0.3.*
+httpcore==0.3.0
 requests==2.*
 
 # Testing


### PR DESCRIPTION
0.3.1 causes a strange issue:

```
response = await requests_async.get('https://example.org')

.direnv/python-3.7.3/lib/python3.7/site-packages/requests_async/adapters.py in send(self, request, stream, timeout, verify, cert, proxies)
     54                 stream=stream,
     55                 ssl=ssl,
---> 56                 timeout=timeout,
     57             )
     58         except socket.error as err:

TypeError: request() got an unexpected keyword argument 'ssl'
```
On 0.3.0 works as expected 
```
In [2]: response = await requests_async.get('https://example.org')

In [3]: response
Out[3]: <Response [HTTPStatus.OK]>
```

I don't know if there is a bug in `httpcore` (which itself works fine for me) or in `requests-async` but until it's resolved, I think version should be frozen to 0.3.0 so people's project won't break.

I feel a bit guilty, as I asked for this release :(
https://github.com/encode/httpcore/issues/80