### PR TITLE
Fix license metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The license is marked as `BSD` on PyPI.

![image](https://user-images.githubusercontent.com/1085180/59924739-c8bf2800-940c-11e9-92ab-d01320d7db0e.png)
